### PR TITLE
docs: expand documentation and FAQ

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,54 +1,37 @@
-# Starlight Starter Kit: Basics
+# Ecency Documentation
 
-[![Built with Starlight](https://astro.badg.es/v2/built-with-starlight/tiny.svg)](https://starlight.astro.build)
+This repository contains the source for the [Ecency](https://ecency.com) documentation site.  The site is built with [Astro](https://astro.build) using the [Starlight](https://starlight.astro.build) theme.
 
-```
-yarn create astro@latest -- --template starlight
-```
+## Project Structure
 
-[![Open in StackBlitz](https://developer.stackblitz.com/img/open_in_stackblitz.svg)](https://stackblitz.com/github/withastro/starlight/tree/main/examples/basics)
-[![Open with CodeSandbox](https://assets.codesandbox.io/github/button-edit-lime.svg)](https://codesandbox.io/p/sandbox/github/withastro/starlight/tree/main/examples/basics)
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/withastro/starlight&create_from_path=examples/basics)
-[![Deploy with Vercel](https://vercel.com/button)](https://vercel.com/new/clone?repository-url=https%3A%2F%2Fgithub.com%2Fwithastro%2Fstarlight%2Ftree%2Fmain%2Fexamples%2Fbasics&project-name=my-starlight-docs&repository-name=my-starlight-docs)
+Documentation content lives in [`src/content/docs`](src/content/docs).  Each Markdown (`.md`/`.mdx`) file in that directory becomes a page in the generated site.  Static assets can be placed in `public/` and referenced with relative links.
 
-> 🧑‍🚀 **Seasoned astronaut?** Delete this file. Have fun!
+## Development
 
-## 🚀 Project Structure
+Install dependencies and start a local development server:
 
-Inside of your Astro + Starlight project, you'll see the following folders and files:
-
-```
-.
-├── public/
-├── src/
-│   ├── assets/
-│   ├── content/
-│   │   ├── docs/
-│   └── content.config.ts
-├── astro.config.mjs
-├── package.json
-└── tsconfig.json
+```bash
+yarn install
+yarn dev
 ```
 
-Starlight looks for `.md` or `.mdx` files in the `src/content/docs/` directory. Each file is exposed as a route based on its file name.
+The site will be available at `http://localhost:4321` and hot–reloads as you edit files.
 
-Images can be added to `src/assets/` and embedded in Markdown with a relative link.
+## Build and Preview
 
-Static assets, like favicons, can be placed in the `public/` directory.
+To create a production build, run:
 
-## 🧞 Commands
+```bash
+yarn build
+```
 
-All commands are run from the root of the project, from a terminal:
+The static site is output to the `dist/` folder.  You can preview the build locally with:
 
-| Command                   | Action                                           |
-| :------------------------ | :----------------------------------------------- |
-| `yarn install`             | Installs dependencies                            |
-| `yarn dev`             | Starts local dev server at `localhost:4321`      |
-| `yarn build`           | Build your production site to `./dist/`          |
-| `yarn preview`         | Preview your build locally, before deploying     |
-| `yarn astro ...`       | Run CLI commands like `astro add`, `astro check` |
-| `yarn astro -- --help` | Get help using the Astro CLI                     |
+```bash
+yarn preview
+```
 
-## 👀 Want to learn more?
+## Contributing
 
-Check out [Starlight’s docs](https://starlight.astro.build/), read [the Astro documentation](https://docs.astro.build), or jump into the [Astro Discord server](https://astro.build/chat).
+Improvements and additions are welcome!  Fork this repository, create your changes in `src/content/docs`, and open a pull request.  For more information see the [contribution guide](src/content/docs/contribution.md).
+

--- a/src/content/docs/contribution.md
+++ b/src/content/docs/contribution.md
@@ -2,6 +2,17 @@
 title: Contribution
 ---
 
-## How to contribute to the Ecency?
+## How to contribute to Ecency?
 
-Our awesome contributors helping us to shape Ecency. You can be part of this great movement, by joining our Translation team: Website, Mobile or by contributing with Ideas, Developing, Designing, Social media outreach skills. We try our best to support our contributors!
+Ecency grows through community effort.  You can help by translating the app, improving documentation, developing new features, designing interfaces, or simply spreading the word.
+
+### Documentation and code
+
+1. Fork this repository and clone it locally.
+2. Create or update Markdown files under `src/content/docs/`.
+3. Preview your changes with `yarn dev`.
+4. Commit your work and open a pull request.
+
+### Translations and ideas
+
+Join our translation teams or share ideas and feedback in the Ecency [Discord server](https://discord.gg/ecency).  We try our best to support all contributors!

--- a/src/content/docs/faq.md
+++ b/src/content/docs/faq.md
@@ -2,37 +2,113 @@
 title: Frequently asked questions
 ---
 
-## Can I change my username?
+Below are answers to common questions about Ecency and the Hive blockchain.
 
-Account names on Ecency and Hive blockchain can not be changed. If you would like a new account name, you can create new account.
+## About Ecency
 
-## Can I delete or deactivate my account?
+### What is Ecency?
 
-Accounts on Ecency can not be deactivated or deleted. The account along with all of its activity is permanently stored in the Hive blockchain.
+Ecency is a decentralized social network built on the [Hive blockchain](https://hive.io) where users own their accounts and content. Learn more in [What is Ecency?](/get-started/what-is-ecency/).
 
-## What is Keychain?
+### What is the Hive blockchain?
 
-Hive Keychain is a wallet browser extension for the Hive blockchain and cryptocurrency and allows users to securely log into and access multiple Hive-based platforms. It is available for Chrome, Brave, and Firefox.
+Hive is a fast, feeless blockchain for Web3 applications. See [What is Hive?](/hive/what-is-hive/) for an overview.
 
-## What kind of information is shown on my profile?
+### How does Ecency work?
 
-The initial details displayed alongside your picture include your reputation score, display name, and description. Below that, you can find information about your followers, the accounts you are following, and your registration date on Ecency. In the Ecency settings, you can choose to add additional details such as your bio, profile picture, cover image, and location.
+Ecency reads and writes data to Hive and rewards contributions with blockchain tokens and Ecency Points. The [How it works guide](/get-started/how-it-works/) explains the process.
 
-## What can I do if my HIVE or Hive dollar tokens are stolen or sent to the wrong account?
+### How do I join Ecency?
 
-If your liquid tokens are stolen or sent to the wrong account, there is no action you can take. However, if your tokens are in Hive Power, the chances of being hacked are less than 1/13 per week. Additionally, if your tokens are in savings, there is a three-day waiting period before they can be transferred. It may be safer to stake/power up or transfer funds into savings.
+Create an account on the [signup page](https://ecency.com/signup?referral=ecency) or follow the [account creation guide](/guides/create-account/). Remember to store your master password safely.
 
-## What are the dollar amounts next to posts and comments?
+### What makes Ecency different from other social networks?
 
-The estimated dollar amounts displayed next to posts and comments represent the potential payout that will be received at the end of the payout period. This estimate is based on the current voting activity and price of HIVE. The actual payout may fluctuate until the period ends. Payouts are a combination of Hive Power and Hive Dollars, although in certain cases, HIVE may be used instead of Hive Dollars depending on market conditions.
+Content is stored on a blockchain, making it immutable and censorship resistant. See [why Ecency is different](/get-started/difference/) for more details.
 
-## How DHF works?
+## Accounts and security
 
-Anyone can create a proposal and convince community to vote on their proposal to get funded. Before creating proposal, normal post should be published on blockchain and it is recommended to gather feedback before creating proposal. Proposal creation has fee of 10 HBD + 1 HBD for each day it lasts over 60 days.
+### Can I change or delete my account?
 
-Once proposal reaches certain threshold of tallied votes, it will start receiving funds each hour. If proposal falls below threshold, system will halt funding for that proposal. You can vote as many proposals as you want, there are no limits. Proposal cannot be edited, but can be deleted/withdrawn by creator.
+Hive account names are permanent and accounts cannot be deleted. You can always [create a new account](/guides/create-account/).
 
-## How to vote proposals?
+### How do I sign in?
 
-Go to the Proposals Page there you can see all Proposals that can be voted on. You can click on them to see further information about the proposal before voting or you can click on the voting icon near the proposal without opening.
+Log in with your Hive username and master password, active key, or via [Hivesigner](https://hivesigner.com). For key details see [Account security and keys](/common/keys/).
+
+### How does the referral system work?
+
+Share a signup link like `https://ecency.com/signup?referral=USERNAME`. When a referral earns 250 Points you receive 100 Points. See the [referral program](/get-started/referral/) for more.
+
+### What is Hive Keychain?
+
+[Hive Keychain](https://hive-keychain.com) is a browser extension and mobile app for securely using Hive applications.
+
+### What if my tokens are stolen or sent to the wrong account?
+
+Blockchain transactions are irreversible. Keeping funds in Hive Power or savings offers more protection.
+
+### How can I recover a lost account?
+
+Account recovery is possible within 30 days if you retain your previous owner key. Follow the [account recovery guide](/guides/recovery/).
+
+## Using Ecency
+
+### Is there a mobile app?
+
+Yes, Ecency provides Android and iOS apps. See the [mobile app guide](/guides/use-mobile-app/) for download links.
+
+### What are Ecency Points and how do I earn them?
+
+Points reward engagement and can be spent to boost or promote posts. Earning methods are listed on the [Ecency Points page](/ecency/ecency-points/).
+
+### Why can't I post or comment?
+
+You may be out of [Resource Credits](/common/resource-credits/what-is-it/). RC regenerate over time or with more Hive Power. You can also request temporary delegation via the [boost page](https://ecency.com/purchase?type=boost).
+
+### What is considered spam or abuse?
+
+See the [posting guidelines](/common/posting/#what-is-considered-spam-or-abuse) for examples of behavior that may be downvoted or removed.
+
+### How do I power up or power down HIVE?
+
+Use the wallet options to convert between liquid HIVE and Hive Power. The [power up/down guide](/guides/power-up-down/) covers the steps.
+
+## Content and rewards
+
+### What are the dollar amounts next to posts and comments?
+
+They estimate the pending payout after seven days. Rewards are explained in [Hive curation and rewards](/hive/curation-and-rewards/).
+
+### How are author and curation rewards split?
+
+At payout, authors and curators each receive 50% of the rewards unless beneficiaries are set or rewards are declined.
+
+### What is voting mana?
+
+Voting power decreases with each vote and regenerates by about 20% per day. See [voting power](/common/resource-credits/voting-power/) for details.
+
+### When can I claim my rewards?
+
+Rewards become claimable seven days after the post or comment is published. Use the **Claim Rewards** button in your wallet.
+
+## Wallet and tokens
+
+### What is the difference between HIVE and Hive Dollars (HBD)?
+
+HIVE is the native liquid token; HBD is a stable-value token. Learn more in [Hive tokens](/common/hive-tokens/).
+
+### How do I convert between HIVE and HBD?
+
+Use the **Convert** option in your wallet or trade on a supported market. Converting HBD to HIVE takes about 3.5 days.
+
+## Proposals and governance
+
+### How does the Decentralized Hive Fund (DHF) work?
+
+Anyone can create a proposal for community funding. Once it reaches the required vote threshold it receives hourly payouts until it falls below that level.
+
+### How do I vote on proposals?
+
+Visit the [Proposals page](https://ecency.com/proposals) and use the vote icon next to a proposal you support.
 


### PR DESCRIPTION
## Summary
- update README with project overview and build instructions
- expand contribution guide with steps for docs and translations
- reorganize FAQ to link to detailed guides and remove repetition
- add FAQ entries about earning Points, Resource Credits, power operations, and account recovery
- detail Hive key types, content rewards, wallet token conversions, and additional platform FAQs

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689ecf7c2b7c832fad671fb298b7f6f6