### PR TITLE
docs: realign Boost+ and Boost terminology

### DIFF
--- a/src/content/docs/common/resource-credits/what-is-it.md
+++ b/src/content/docs/common/resource-credits/what-is-it.md
@@ -6,7 +6,7 @@ Transacting on the Hive blockchain has zero fees, transaction rate-limiting is e
 
 Every user has a limited amount of Resource Credits to use each week. The more transactions a user does, the less Resource Credits they will have left (until they recharge). Users with more HIVE POWER will have more Resource Credits.
 
-If you run out of Resource Credits, you will be unable to transact with the blockchain until your Resource Credits recharge (happens automatically) or you acquire additional HIVE POWER to increase your Resource Credit balance or you can request Boosting account from Ecency to receive temporary delegation.
+If you run out of Resource Credits, you will be unable to transact with the blockchain until your Resource Credits recharge (happens automatically), you acquire additional HIVE POWER, **request Boost+** using Ecency Points, or purchase a **Boost (Account Boost)** in the mobile app to receive a temporary delegation.
 
 ## What's possible with my current available RC?
 

--- a/src/content/docs/ecency/boost-and-promote.md
+++ b/src/content/docs/ecency/boost-and-promote.md
@@ -1,29 +1,47 @@
 ---
 title: Boost and Promote
-description: Use Ecency Points to increase your post visibility on the Hive blockchain.
+description: Clarifies Boost+, Boost (Account Boost), and Promote to increase visibility on the Hive blockchain.
 ---
 
 # Boost and Promote on Ecency
 
-Ecency offers two unique tools — **Boost** and **Promote** — that help increase visibility of your Hive posts. These tools are powered by Ecency Points and are available to all users on the Ecency platform.
+Ecency offers tools like **Boost+**, **Boost (Account Boost)**, and **Promote** that help increase visibility of your Hive posts. These tools are powered by Ecency Points or mobile in-app purchases and are available to all users on the Ecency platform.
 
 ---
 
-## What is Boost?
+## What is Boost+?
 
-**Boost** uses your Ecency Points to support your account with potential **delegations** from Ecency accounts and partner delegators.
+**Boost+** uses your Ecency Points to support your account with potential **delegations** from Ecency accounts and partner delegators.
 
 ### Key Features:
 - May receive **delegations** on your account.
 - Great for **content curation** and **organic reach**.
 - Consumes more points than Promote.
 
-### How to Use Boost:
-1. Go to Perks or profile page on Ecency, click the **“Boost”** button.
+### How to Use Boost+:
+1. Go to Perks or profile page on Ecency, click the **“Boost+”** button.
 2. Choose the number of points to use.
 3. Confirm and wait for delegations to arrive over the next few hours.
 
-> 💡 Boosting doesn't guarantee votes, but higher boosts often get you more curation rewards and reward others It also gives you more Resource Credits.
+> 💡 Boost+ doesn't guarantee votes, but higher boosts often get you more curation rewards and reward others. It also gives you more Resource Credits.
+>
+> ⚠️ Don't confuse Boost+ with **Boost (Account Boost)**, a separate mobile-only feature purchased via in-app stores and not tied to Ecency Points.
+
+---
+
+## Boost (Account Boost)
+
+**Boost**, also called **Account Boost**, is available only through the Ecency mobile app as an **in-app purchase**. It grants your account a temporary **Hive Power delegation for 30 days** and doesn't consume Ecency Points.
+
+### Key Features:
+- Provides **HP delegation** for 30 days.
+- Purchased via **in-app purchase** in the mobile app.
+- Does **not** require Ecency Points.
+
+### How to Use Boost:
+1. Open the Ecency mobile app and go to **Perks** or your **wallet**.
+2. Select **Boost** and complete the in-app purchase.
+3. Delegation arrives almost instantly and expires after 30 days.
 
 ---
 
@@ -45,16 +63,16 @@ Ecency offers two unique tools — **Boost** and **Promote** — that help incre
 
 ## Comparison
 
-| Feature  | Boost                     | Promote                     |
-|----------|---------------------------|-----------------------------|
-| Purpose  | Delegations               | Visibility                  |
-| Cost     | Higher                    | Lower                       |
-| Reward   | May earn curation rewards | No rewards                  |
-| Visibility | Organic (curation-based)  | Static (promoted feed)      |
+| Feature  | Boost+ (Points)           | Boost (Account Boost)      | Promote                     |
+|----------|---------------------------|-----------------------------|-----------------------------|
+| Purpose  | Delegations               | 30-day HP delegation        | Visibility                  |
+| Cost     | Higher (points)           | In-app purchase             | Lower (points)              |
+| Reward   | May earn curation rewards | No rewards                  | No rewards                  |
+| Visibility | Organic (curation-based) | Organic (delegation-based) | Static (promoted feed)      |
 
 ---
 
-## Where to Find Boost/Promote
+## Where to Find Boost+/Promote
 
 You can Promote posts from:
 
@@ -66,11 +84,14 @@ Works on:
 - [Web](https://ecency.com)
 - [Mobile apps](https://ecency.com/mobile)
 
+Boost (Account Boost) is available in the mobile app via Perks or your wallet.
+
 ---
 
 ## Final Notes
 
 - You can Promote your own or other people’s posts.
-- You can only use Ecency Points (not HIVE or HBD) for these features.
-- Boost results vary based on content quality and timing.
+- Boost+ and Promote use Ecency Points (not HIVE or HBD).
+- Boost requires an in-app purchase.
+- Boost+ results vary based on content quality and timing.
 

--- a/src/content/docs/ecency/ecency-points.md
+++ b/src/content/docs/ecency/ecency-points.md
@@ -1,6 +1,6 @@
 ---
 title: Ecency Points
-description: Learn how Ecency Points work and how to use them for Boost and Promote.
+description: Learn how Ecency Points work and how to use them for Boost+ and Promote.
 ---
 
 # Ecency Points
@@ -28,18 +28,18 @@ You can earn Ecency Points by:
 
 Ecency Points can be spent for:
 
-- **Boost**: Promote your posts for more visibility. Uses points to increase chance of getting votes from Ecency-supported accounts.
+- **Boost+**: Request a temporary **Hive Power delegation** to your account.
 - **Promote**: Advertise your post in the promoted section of Ecency.
 - **Gifts**: Send points to other users as a tip or reward.
 - **Future Utilities**: Ecency is continually expanding use-cases for points.
 
 ---
 
-## Boost vs Promote
+## Boost+ vs Promote
 
 | Feature | Description |
 |--------|-------------|
-| **Boost** | Increases visibility by increasing vote chances. Costs more points but can lead to curation rewards. |
+| **Boost+** | Grants temporary Hive Power delegation using your points. Can lead to curation rewards and more Resource Credits. |
 | **Promote** | Lists post in promoted sections (Web, Mobile) with no votes guaranteed. Lower cost. |
 
 ---
@@ -70,6 +70,7 @@ You can send points to other users:
 - They are **not a token** on the Hive blockchain.
 - Ecency regularly supports promotions and airdrops based on activity.
 - Community does create extra utility on various self hosted games.
+- **Boost (Account Boost)** is a separate mobile-only feature purchased via in-app stores that provides a 30-day Hive Power delegation without using points.
 
 ---
 

--- a/src/content/docs/ecency/ecency-vs-others.md
+++ b/src/content/docs/ecency/ecency-vs-others.md
@@ -27,7 +27,8 @@ Each frontend uses the same Hive blockchain data — but presents it differently
 | Feature            | Ecency                              |
 |--------------------|--------------------------------------|
 | Platforms          | Web, Desktop, iOS, Android           |
-| Boost/Promote      | ✅ Yes (via Ecency Points)           |
+| Boost+/Promote     | ✅ Yes (via Ecency Points)           |
+| Boost (Account Boost) | ✅ Mobile-only, in-app purchase delegation |
 | Wallet             | ✅ Built-in, with key import support |
 | Notifications      | ✅ Real-time, cross-device           |
 | Multi-account      | ✅ Seamless switching                |
@@ -41,7 +42,7 @@ Each frontend uses the same Hive blockchain data — but presents it differently
 | Feature        | **Ecency** | **PeakD** | **LeoFinance** | **Hive.blog** |
 |----------------|------------|-----------|----------------|---------------|
 | Multi-platform | ✅ Web, Mobile, Desktop | Web only | Web only | Web only |
-| Boost System   | ✅ Yes (Points) | ❌ | ❌ | ❌ |
+| Boost+ System  | ✅ Yes (Points) | ❌ | ❌ | ❌ |
 | Notifications  | ✅ Real-time  | ✅ via browser | ❌ | ❌ |
 | Community UI   | ✅ Yes       | ✅ Yes       | ✅ Focused | Basic         |
 | Editor         | ✍️ Rich + Markdown | Rich + Markdown | Basic | Markdown only |
@@ -53,7 +54,7 @@ Each frontend uses the same Hive blockchain data — but presents it differently
 
 - You want a **modern UI** and mobile support
 - You enjoy **earning extra points** for engagement
-- You want Boost/Promote tools to grow your content reach
+- You want Boost+ or Promote tools, or Boost (Account Boost), to grow your content reach
 - You need a **smooth experience across devices**
 - You’re a beginner and want an easier onboarding
 

--- a/src/content/docs/ecency/wallet.md
+++ b/src/content/docs/ecency/wallet.md
@@ -87,7 +87,7 @@ Transferring HBD into savings earns you 15-20% (subject to governance settings) 
 |------------|--------------------------------------------------|
 | **Tokens** | View HIVE, HP, HBD, and Points                   |
 | **Activity** | Recent transfers, votes, rewards, boosts       |
-| **Boosts** | View recent Boost/Promote activity               |
+| **Boosts** | View recent Boost+, Boost (Account Boost), and Promote activity |
 | **Savings** | Manage savings balance                          |
 
 ---

--- a/src/content/docs/get-started/what-is-ecency.md
+++ b/src/content/docs/get-started/what-is-ecency.md
@@ -14,7 +14,7 @@ Ecency makes Hive accessible through web, desktop, and mobile apps, offering a m
 - **Accessible**: Use Ecency from anywhere – desktop, mobile app, or browser.
 - **Integrated Wallet**: View balances, send tokens, power up/down.
 - **Content Creation**: Draft, schedule, and publish posts with rich editing tools.
-- **Reward Tools**: Use Boost and Promote features to gain visibility.
+- **Reward Tools**: Use Boost+ (delegations with points) and Promote features to gain visibility.
 - **Points System**: Earn Ecency Points for your activity and engagement.
 
 ## Platforms
@@ -26,7 +26,8 @@ Ecency makes Hive accessible through web, desktop, and mobile apps, offering a m
 
 - **Hive Integration**: Everything you do is stored on Hive.
 - **Ecency Points**: Bonus point system that rewards users for activity.
-- **Boost/Promote**: Gain visibility with on-chain and off-chain promotion tools.
+- **Boost+/Promote**: Gain visibility with on-chain and off-chain promotion tools.
+- **Boost (Account Boost)**: Mobile-only in-app purchase that provides a 30-day Hive Power delegation.
 - **Waves**: Short content creation and engagement.
 - **Communities**: Explore Hive's topic, journal and council based communities.
 - **Multi-Account Support**: Manage multiple Hive accounts with ease.

--- a/src/content/docs/guides/use-mobile-app.md
+++ b/src/content/docs/guides/use-mobile-app.md
@@ -22,7 +22,8 @@ Also available at: [https://github.com/ecency-mobile](https://github.com/ecency-
 
 - Post and edit Hive content
 - Vote, comment, and reply
-- Use Boost/Promote with Ecency Points
+- Use Boost+/Promote with Ecency Points
+- Purchase **Boost (Account Boost)** for 30-day HP delegation
 - View wallet and transaction history
 - Bookmark and draft posts
 - Real-time notifications
@@ -58,6 +59,14 @@ Also available at: [https://github.com/ecency-mobile](https://github.com/ecency-
 - Power up/down, send HIVE or HBD
 - Check Ecency Points, Boosted, and Promoted status
 - Check and enable Layer 2 tokens for quicker access
+
+---
+
+## Boost (Account Boost)
+
+- Available only on the mobile app via **in-app purchase**
+- Grants a **Hive Power delegation** for **30 days**
+- Doesn't spend your Ecency Points
 
 ---
 


### PR DESCRIPTION
## Summary
- distinguish Boost+ (points-based delegation) from Boost (Account Boost) across docs
- update points, onboarding, wallet, and resource credit guides to match new naming
- clarify mobile app guide on purchasing Boost and using Boost+

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2bda30950832f88a60f64c312a036