### PR TITLE
docs: add Waves overview

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -69,6 +69,10 @@ export default defineConfig({
               label: "Decks",
               items: [{ label: "What are Decks?", slug: "ecency/decks/about" }],
             },
+            {
+              label: "Waves",
+              items: [{ label: "What are Waves?", slug: "ecency/waves/about" }],
+            },
             { label: "Market", slug: "ecency/market" },
             { label: "Mobile App", slug: "guides/use-mobile-app" },
             { label: "Ecency Wallet", slug: "ecency/wallet" },

--- a/src/content/docs/ecency/waves/about.md
+++ b/src/content/docs/ecency/waves/about.md
@@ -1,0 +1,16 @@
+---
+title: What are Waves?
+---
+
+Waves are Ecency's home for short-form content. They let you share brief updates, images, or links without writing a full post, making it easy to microblog on Hive.
+
+## Other short-form content on Hive
+
+Different communities have their own names for quick posts:
+
+- **Threads** – bite-sized discussions in the LeoFinance community.
+- **Snaps** – short content from the Peakd team and community.
+- **Moments** – photo updates from the Liketu community.
+- **Buzz** – micro posts on D.Buzz.
+
+Waves brings these styles together so you can explore and interact with short content from across Hive in one place.


### PR DESCRIPTION
## Summary
- document Waves as Ecency's short-form content and mention similar formats like threads, snaps, moments, buzz
- add Waves to navigation
- note that Snaps are short content from the Peakd team and community

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2c1d819ec832f98f61bbb974a8cc9