### PR TITLE
docs: add guide on creating communities

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -84,6 +84,7 @@ export default defineConfig({
             { label: "Account recovery", slug: "guides/recovery" },
             { label: "Power up/down", slug: "guides/power-up-down" },
             { label: "Delegate Hive Power", slug: "guides/delegate-hp" },
+            { label: "Create community", slug: "guides/create-community" },
           ],
         },
         {

--- a/src/content/docs/guides/create-community.md
+++ b/src/content/docs/guides/create-community.md
@@ -1,0 +1,19 @@
+---
+title: Create a Community
+description: Step-by-step guide on how to create a community on Ecency.
+---
+
+# Create a Community
+
+Communities bring people together around shared interests on the Hive blockchain. Follow these steps to create your own community using Ecency.
+
+1. Sign in to [Ecency.com](https://ecency.com) with your Hive account.
+2. Navigate to the [Communities](https://ecency.com/communities) page and click **Create community**.
+3. Fill out the required details such as **name**, **description**, **avatar**, **banner**, and **community type**:
+   - **Topic** – anyone can post or comment
+   - **Journal** – guests can comment but only members can post
+   - **Council** – only members can post or comment
+4. Review the community settings and press **Create**. Creating a community burns a small fee (currently 3 HIVE).
+5. A new account like `hive-123456` will be generated. You are its owner and can manage settings, moderators, and rules from the community page.
+
+Your community is now live! Start posting, invite members, and grow conversations around your topic.


### PR DESCRIPTION
## Summary
- document steps to create a community on Ecency
- expose community creation guide in sidebar
- mention available community types

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a2c267be40832f91e11c97113fb8a0