### PR TITLE
Add extra services to developers sidebar

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -96,6 +96,14 @@ export default defineConfig({
           items: [
             { label: "Ecency SDK", slug: "developers/wallets" },
             { label: "API Reference", slug: "developers/api" }, // if you later add this
+            {
+              label: "Extra services",
+              items: [
+                { label: "Hivesearcher", slug: "extra-services/hivesearcher" },
+                { label: "Hivesigner", slug: "extra-services/hivesigner" },
+                { label: "Hivexplorer", slug: "extra-services/hivexplorer" },
+              ],
+            },
           ],
         },
         { label: "FAQ", slug: "faq" },


### PR DESCRIPTION
## Summary
- add Hivesearcher, Hivesigner, and Hivexplorer links under Developers sidebar section

## Testing
- `yarn build`

------
https://chatgpt.com/codex/tasks/task_e_68a310d1634c832fb2f9333f20e1cf6b