### PR TITLE
Consolidate Hivesigner docs under extra services

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -54,10 +54,6 @@ export default defineConfig({
             { label: "Reputation", slug: "common/reputation" },
             { label: "Discover", slug: "common/discover" },
             { label: "Witness voting", slug: "guides/vote-witness" },
-            {
-              label: "Hivesigner",
-              items: [{ label: "What is it?", slug: "hive/hivesigner/about" }],
-            },
           ],
         },
         {

--- a/src/content/docs/extra-services/hivesigner.md
+++ b/src/content/docs/extra-services/hivesigner.md
@@ -4,5 +4,9 @@ title: Hivesigner
 
 [Hivesigner.com](https://hivesigner.com) is a secure authentication (OAuth2) service co-developed and maintained by Ecency.
 It lets you sign in to Hive applications and approve transactions without exposing your private keys.
+Applications built on Hive can integrate Hivesigner to handle user authentication without requesting or storing their credentials directly.
+When you registered on Hive, you were provided with numerous keys that are difficult to recall.
+Hivesigner allows you to create a memorable password and avoid using your active key when logging into Hive platforms.
 Hivesigner supports posting, voting, transfers, and other common operations while keeping your credentials safe.
+Because it isolates apps from your private keys, Hivesigner is one of the most secure ways to log in and sign transactions across the Hive ecosystem.
 See the [Hivesigner documentation](https://docs.hivesigner.com) for integration guides and API references.

--- a/src/content/docs/hive/hivesigner/about.md
+++ b/src/content/docs/hive/hivesigner/about.md
@@ -1,5 +1,0 @@
----
-title: What is Hivesigner?
----
-
-When you registered on Hive, you were provided with numerous keys that are difficult to recall. The purpose of Hivesigner is to allow you to generate a password that is memorable to you and to safeguard against using your active key when logging into Hive platforms.


### PR DESCRIPTION
## Summary
- Merge Hivesigner information into one page under `extra services`
- Remove redundant `hive/hivesigner/about` page
- Update navigation to list Hivesigner only under extra services
- Note that apps can integrate Hivesigner for secure authentication without requesting user credentials
- Highlight Hivesigner as one of the safest ways to log in and sign transactions

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a55cee17e4832f85c4c28062c84338