### PR TITLE
Docs: Ecency Pro + Blog hosting

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -64,6 +64,8 @@ export default defineConfig({
             { label: "Mobile App", slug: "guides/use-mobile-app" },
             { label: "Mobile FAQ", slug: "ecency/mobile-faq" },
             { label: "Ecency Points", slug: "ecency/ecency-points" },
+            { label: "Ecency Pro", slug: "ecency/ecency-pro" },
+            { label: "Blog hosting", slug: "ecency/blog-hosting" },
             { label: "Boost and Promote", slug: "ecency/boost-and-promote" },
             { label: "Notifications, Drafts, Bookmarks", slug: "ecency/notifications-drafts-bookmarks" },
             {

--- a/src/content/docs/ecency/blog-hosting.md
+++ b/src/content/docs/ecency/blog-hosting.md
@@ -1,0 +1,41 @@
+---
+title: Blog hosting
+description: Host your Hive blog on your own Ecency subdomain with a simple monthly plan.
+---
+
+# Blog hosting
+
+Ecency blog hosting gives you your own hosted blog at `yourname.blogs.ecency.com`, powered by your Hive account and content. It is a fast way to run a clean, standalone blog without managing any servers yourself.
+
+## What you get
+
+- **Your own subdomain.** A dedicated blog at `yourname.blogs.ecency.com`.
+- **Your Hive content.** Your posts rendered on a clean, readable blog theme.
+- **Nothing to maintain.** Ecency hosts and serves the blog for you.
+- **Simple setup.** Pick a name, add a title and description, pay, and you are live.
+
+## Price
+
+Blog hosting is **2 HBD or about $2 per month**. You can pay for 1, 3, 6, or 12 months at a time.
+
+## Payment options
+
+- **HBD** (Hive Backed Dollars) straight from your Hive wallet.
+- **Card** for a familiar checkout.
+- **x402**, Ecency's own crypto payment protocol.
+
+## How to set up
+
+1. Go to `ecency.com/hosting`.
+2. Choose your blog name. This becomes `yourname.blogs.ecency.com`.
+3. Add a blog title and description.
+4. Pick a term and pay by HBD, card, or x402.
+5. Your blog activates as soon as the payment is confirmed.
+
+## Frequently asked
+
+**Whose content appears on the blog?** Your Hive posts. Because your content lives on Hive, your blog reflects whatever you publish.
+
+**Can I use my own custom domain?** Custom domains may be offered later. For now blogs are served on the `blogs.ecency.com` subdomain.
+
+**What happens when the term ends?** Renew to keep your blog active. You can pay for another term at any time.

--- a/src/content/docs/ecency/blog-hosting.md
+++ b/src/content/docs/ecency/blog-hosting.md
@@ -5,7 +5,16 @@ description: Host your Hive blog on your own Ecency subdomain with a simple mont
 
 # Blog hosting
 
-Ecency blog hosting gives you your own hosted blog at `yourname.blogs.ecency.com`, powered by your Hive account and content. It is a fast way to run a clean, standalone blog without managing any servers yourself.
+Ecency blog hosting gives you your own hosted blog at `yourname.blogs.ecency.com` (or your own custom domain), powered by your Hive account and content. It is a fast way to run a clean, standalone site that is yours, without managing any servers yourself.
+
+## Why a hosted blog?
+
+Your Ecency profile at `ecency.com/@username` lives inside the main Ecency site, alongside everyone else's content and under Ecency's branding. A hosted blog is the opposite: it is **your own space**.
+
+- **Only your content.** Readers see your posts on a page dedicated to you, with nothing else competing for attention.
+- **Your brand.** Your name, title, theme, and layout, instead of the shared Ecency shell.
+- **Your address.** A memorable `yourname.blogs.ecency.com`, or your own domain like `blog.yoursite.com`.
+- **Still on Hive.** Your posts stay on the Hive blockchain, so you keep your audience, rewards, and portability. The blog is simply a nicer front door to the same content.
 
 ## What you get
 

--- a/src/content/docs/ecency/blog-hosting.md
+++ b/src/content/docs/ecency/blog-hosting.md
@@ -54,6 +54,16 @@ Want your blog on your own domain, like `blog.yoursite.com`? Add the **Custom do
 
 Custom domains need the Custom domain plan; standard blogs use the `blogs.ecency.com` subdomain. Custom-domain checkout is a one-step card payment.
 
+## Community hosting
+
+Hosting is not only for personal blogs. You can host a whole Hive community as its own branded site, showing the community's posts, subscribers, and about, at `hive-NNNNN.blogs.ecency.com` or your own custom domain. It gives a community a home that looks and feels like its own, while every post stays on Hive.
+
+- **You control it, not the community account.** The instance is owned by the account that creates it (you), separate from the community itself. You never need the community's keys to run or customize the site.
+- **Members post into the community.** From the hosted site, a logged-in member can publish straight into the community, and normal Hive community moderation still applies.
+- **Same customization.** Choose a theme, a style template, a title, and branding, and add a custom domain just like a personal blog.
+
+To set one up, go to `ecency.com/hosting`, choose **Community**, and enter the community id (it looks like `hive-125125`). You must be logged in, since your account becomes the owner. Pick a term and pay by HBD or card. The community activates as soon as the payment is confirmed.
+
 ## Frequently asked
 
 **Whose content appears on the blog?** Your Hive posts. Because your content lives on Hive, your blog reflects whatever you publish.
@@ -61,3 +71,5 @@ Custom domains need the Custom domain plan; standard blogs use the `blogs.ecency
 **Can I use my own custom domain?** Yes. Add the Custom domain option for +$1 per month. See the Custom domain section above.
 
 **What happens when the term ends?** Renew to keep your blog active. You can pay for another term at any time.
+
+**Can I host a community instead of a personal blog?** Yes. Choose Community at signup and enter the community id. Your account becomes the owner and controls the site, separate from the community account. See the Community hosting section above.

--- a/src/content/docs/ecency/blog-hosting.md
+++ b/src/content/docs/ecency/blog-hosting.md
@@ -18,11 +18,13 @@ Ecency blog hosting gives you your own hosted blog at `yourname.blogs.ecency.com
 
 Blog hosting is **2 HBD or about $2 per month**. You can pay for 1, 3, 6, or 12 months at a time.
 
+**Free with Ecency Pro.** Every [Ecency Pro](/ecency/ecency-pro) member gets a blog included, so you can claim one without paying for hosting separately.
+
 ## Payment options
 
 - **HBD** (Hive Backed Dollars) straight from your Hive wallet.
 - **Card** for a familiar checkout.
-- **x402**, Ecency's own crypto payment protocol.
+- **x402**, Ecency's own internet-native payment protocol. It is an agentic rail, so a script or AI agent can pay for and provision a blog programmatically. See [x402 payments](/developers/x402) for the developer flow.
 
 ## How to set up
 
@@ -32,10 +34,21 @@ Blog hosting is **2 HBD or about $2 per month**. You can pay for 1, 3, 6, or 12 
 4. Pick a term and pay by HBD, card, or x402.
 5. Your blog activates as soon as the payment is confirmed.
 
+## Custom domain
+
+Want your blog on your own domain, like `blog.yoursite.com`? Add the **Custom domain** option for **+$1 per month** ($3 per month total). After your blog is active:
+
+1. In the **Add your custom domain** step, enter your domain.
+2. At your DNS provider, add the **CNAME** record shown (its name is a verification token, and it points to `yourname.blogs.ecency.com`).
+3. Click **Verify**. DNS can take a few minutes to propagate.
+4. Once verified, your blog is served on your custom domain.
+
+Custom domains need the Custom domain plan; standard blogs use the `blogs.ecency.com` subdomain. Custom-domain checkout is a one-step card payment.
+
 ## Frequently asked
 
 **Whose content appears on the blog?** Your Hive posts. Because your content lives on Hive, your blog reflects whatever you publish.
 
-**Can I use my own custom domain?** Custom domains may be offered later. For now blogs are served on the `blogs.ecency.com` subdomain.
+**Can I use my own custom domain?** Yes. Add the Custom domain option for +$1 per month. See the Custom domain section above.
 
 **What happens when the term ends?** Renew to keep your blog active. You can pay for another term at any time.

--- a/src/content/docs/ecency/ecency-pro.md
+++ b/src/content/docs/ecency/ecency-pro.md
@@ -10,6 +10,7 @@ Ecency Pro is an annual membership that adds a set of premium perks on top of yo
 ## What you get
 
 - **Verified Pro badge.** A checkmark shown next to your name across Ecency on both web and mobile, so readers can recognize you as a Pro member.
+- **A free blog.** Your own hosted blog at `yourname.blogs.ecency.com`, included with Pro. Claim it from the Perks page after you upgrade. See [Blog hosting](/ecency/blog-hosting).
 - **Insights for any creator.** View traffic insights (views, unique views, time on page) for any profile, not just your own. This is a handy way to research what topics and formats perform well.
 - **A larger AI free allowance.** Extra daily free uses of Ecency's AI features, including the writing assistant and the AI image generator, on top of what regular accounts get.
 - **Free streak freezes.** Protect your daily activity streak without spending Points.

--- a/src/content/docs/ecency/ecency-pro.md
+++ b/src/content/docs/ecency/ecency-pro.md
@@ -1,0 +1,38 @@
+---
+title: Ecency Pro
+description: What Ecency Pro includes, how much it costs, and how to subscribe.
+---
+
+# Ecency Pro
+
+Ecency Pro is an annual membership that adds a set of premium perks on top of your regular Ecency account. It is a simple way to support Ecency while unlocking extra tools and recognition.
+
+## What you get
+
+- **Verified Pro badge.** A checkmark shown next to your name across Ecency on both web and mobile, so readers can recognize you as a Pro member.
+- **Insights for any creator.** View traffic insights (views, unique views, time on page) for any profile, not just your own. This is a handy way to research what topics and formats perform well.
+- **A larger AI free allowance.** Extra daily free uses of Ecency's AI features, including the writing assistant and the AI image generator, on top of what regular accounts get.
+- **Free streak freezes.** Protect your daily activity streak without spending Points.
+- **More perks over time.** New Pro benefits are added as they ship.
+
+## Price
+
+Ecency Pro is **$19.99 per year**. You are charged once for a 12 month membership. Renewing extends your membership from your current expiry date, so you never lose any remaining time.
+
+## How to subscribe
+
+1. Open the **Perks** page on Ecency (the gift icon in the menu, or visit `ecency.com/perks`).
+2. Choose **Ecency Pro** and continue to checkout.
+3. Pay by card. Your Pro badge and perks activate as soon as the payment is confirmed.
+
+Payments are handled securely by our payment provider, and your membership is tied to your Hive username.
+
+## Frequently asked
+
+**Does Pro renew automatically?** Not at the moment. You buy a 12 month term and can renew any time to extend it.
+
+**Can I pay with Points or crypto?** Ecency Pro is currently a card purchase. More payment options may be added later.
+
+**Where does my badge appear?** Next to your username on posts, comments, and your profile, on both the website and the mobile app.
+
+**What are Insights?** Insights show how much traffic a profile's posts receive. Your own Insights are always free. With Pro you can also open the Insights tab on other creators' profiles.


### PR DESCRIPTION
Adds two user-facing pages for the newly shipped products, under **Using Ecency**:

- **Ecency Pro** (`ecency/ecency-pro`) — what it includes (verified badge, Insights for any creator, larger AI free allowance, free streak freezes), the $19.99/year price, how to subscribe, and an FAQ.
- **Blog hosting** (`ecency/blog-hosting`) — hosted blog at `yourname.blogs.ecency.com`, pricing (2 HBD / $2 per month), payment options (HBD / card / x402), setup steps, and an FAQ.

Both are added to the sidebar next to Ecency Points. Builds clean locally (`yarn build`, 58 pages).